### PR TITLE
Fix 'import_yaml' issue

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -874,6 +874,7 @@ class Pillar:
                 return None, mods, errors
         state = None
         try:
+            defaults["file_client"] = self.client
             state = compile_template(
                 fn_,
                 self.rend,

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -288,6 +288,9 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     loader = None
     newline = False
 
+    file_client = None
+    if "file_client" in context:
+        file_client = context["file_client"]
     if tmplstr and not isinstance(tmplstr, six.text_type):
         # https://jinja.palletsprojects.com/en/2.11.x/api/#unicode
         tmplstr = tmplstr.decode(SLS_ENCODING)
@@ -302,7 +305,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
             loader = jinja2.FileSystemLoader(os.path.dirname(tmplpath))
     else:
         loader = salt.utils.jinja.SaltCacheLoader(
-            opts, saltenv, pillar_rend=context.get("_pillar_rend", False)
+            opts, saltenv, pillar_rend=context.get("_pillar_rend", False), _file_client=file_client
         )
 
     env_args = {"extensions": [], "loader": loader}


### PR DESCRIPTION
### What does this PR do?
Fix jinja2.exceptions.TemplateNotFound issue on 'import' or 'import_yaml' jinja expression

Main issue was: while salt process top.sls and included files it uses GitPillarClient, but when jinja process their include stuff, it uses PillarClient as a file_client which can work only with the filesystem. 
IDK how exactly it works, but I guess SaltCacheLoader should use right file_client to load nonexistent files into the cache.
So I haven't found anything better then to pass an GitPillarClient object through the some 'global' dictionary named context


### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/39420

### Previous Behavior
Salt throws jinja2.exceptions.TemplateNotFound on {% import_yaml '...' as ... %} expression

### New Behavior
It works

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
